### PR TITLE
feat v1 address cli setup

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,3 +20,4 @@ lazy_static = "1.4"
 console = "0.15"
 rand_chacha = "0.2" 
 futures = "0.3"
+regex = { version = "1.5", default-features = false, features = ["std"] }

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -39,12 +39,12 @@ pub struct Opts {
 
 impl Opts {
     pub fn execute(&self) -> Result<Box<dyn Display>> {
-        let config = Config::load(&self.home)?;
+        let mut config = Config::load(&self.home)?;
 
         match &self.subcmd {
             SubCommand::Asset(c) => c.execute(config),
             SubCommand::Delegate(c) => c.execute(config),
-            SubCommand::Setup(c) => c.execute(config),
+            SubCommand::Setup(c) => c.execute(&mut config),
             SubCommand::Transfer(c) => c.execute(&self.home),
             SubCommand::Wallet(c) => c.execute(&self.home),
         }

--- a/cli/src/command/setup.rs
+++ b/cli/src/command/setup.rs
@@ -2,14 +2,14 @@ use std::fmt::Display;
 
 use crate::config::Config;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {
     static ref RPC_ADDR_REGEX: Regex =
-        Regex::new(r"^(?:http(s)?://)?[\w.-]+(?:\.[\w\.-]+)*:\d*").unwrap();
+        Regex::new(r"(?:https?)://[-a-zA-Z0-9.]+:?([0-9]+)?").unwrap();
 }
 
 #[derive(Parser, Debug)]
@@ -28,7 +28,7 @@ impl Command {
                 bail!("address is not valid: {}", addr)
             }
             config.node.address = addr.clone();
-            config.save()?;
+            config.save().context("save rpc_server_address failed")?;
         }
 
         Ok(Box::new(0))

--- a/cli/src/command/setup.rs
+++ b/cli/src/command/setup.rs
@@ -2,25 +2,43 @@ use std::fmt::Display;
 
 use crate::config::Config;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref RPC_ADDR_REGEX: Regex =
+        Regex::new(r"^(?:http(s)?://)?[\w.-]+(?:\.[\w\.-]+)*:\d*").unwrap();
+}
 
 #[derive(Parser, Debug)]
 pub struct Command {
     #[clap(short, long)]
     /// Set the address of Findora rpc server
-    set_server_address: Option<String>,
+    set_rpc_server_address: Option<String>,
 }
 
 impl Command {
     pub fn execute(&self, config: Config) -> Result<Box<dyn Display>> {
         let mut config = config;
 
-        if let Some(addr) = &self.set_server_address {
+        if let Some(addr) = &self.set_rpc_server_address {
+            if !is_address_validate(addr) {
+                bail!("address is not valid: {}", addr)
+            }
             config.node.address = addr.clone();
             config.save()?;
         }
 
         Ok(Box::new(0))
     }
+}
+
+// using a simple regex checking instead of using url crate,
+// because
+// 1. the rpc address setup comes only in here and it's format is simple
+// 2. regex crate can be re-used in other places but url crate is not
+fn is_address_validate(addr: &str) -> bool {
+    RPC_ADDR_REGEX.is_match(addr)
 }

--- a/cli/src/command/setup.rs
+++ b/cli/src/command/setup.rs
@@ -1,7 +1,5 @@
 use std::fmt::Display;
 
-use crate::config::Config;
-
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use lazy_static::lazy_static;
@@ -20,18 +18,24 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn execute(&self, config: Config) -> Result<Box<dyn Display>> {
+    pub fn execute(&self, config: crate::config::Config) -> Result<Box<dyn Display>> {
         let mut config = config;
+        let mut result = vec![];
 
         if let Some(addr) = &self.set_rpc_server_address {
             if !is_address_validate(addr) {
                 bail!("address is not valid: {}", addr)
             }
+            result.push((
+                "RPC Server Address".to_string(),
+                config.node.address.clone(),
+                addr.clone(),
+            ));
             config.node.address = addr.clone();
-            config.save().context("save rpc_server_address failed")?;
         }
 
-        Ok(Box::new(0))
+        config.save().context("save rpc_server_address failed")?;
+        Ok(Box::new(crate::display::setup::Display::from(result)))
     }
 }
 

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod setup;
 pub(crate) mod wallet;

--- a/cli/src/display/setup.rs
+++ b/cli/src/display/setup.rs
@@ -19,7 +19,7 @@ impl Display {
         writeln!(
             f,
             "{} {}",
-            Emoji("⚠️", "!?"),
+            Emoji("💡", "!?"),
             style("No changes made").bold().yellow()
         )
     }
@@ -30,15 +30,13 @@ impl Display {
                 f,
                 "
 {} {}
-Change from
-{}
-to
-{}
+{} {} {}
             ",
                 Emoji("📃", "!!"),
                 style(content.name.clone()).bold().white(),
-                style(content.before.clone()),
-                style(content.after.clone()),
+                style(content.before.clone()).bold().magenta(),
+                Emoji("➤ ", "->"),
+                style(content.after.clone()).bold().green(),
             )?
         }
         Ok(())

--- a/cli/src/display/setup.rs
+++ b/cli/src/display/setup.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+use console::{style, Emoji};
+
+#[derive(Default, Debug)]
+pub struct Content {
+    pub name: String,
+    pub before: String,
+    pub after: String,
+}
+
+#[derive(Debug)]
+pub struct Display {
+    contents: Vec<Content>,
+}
+
+impl Display {
+    fn empty(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "{} {}",
+            Emoji("⚠️", "!?"),
+            style("No changes made").bold().yellow()
+        )
+    }
+
+    fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for content in self.contents.iter() {
+            write!(
+                f,
+                "
+{} {}
+Change from
+{}
+to
+{}
+            ",
+                Emoji("📃", "!!"),
+                style(content.name.clone()).bold().white(),
+                style(content.before.clone()),
+                style(content.after.clone()),
+            )?
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Display {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.contents.is_empty() {
+            return self.empty(f);
+        }
+
+        self.display(f)
+    }
+}
+
+impl From<Vec<(String, String, String)>> for Display {
+    fn from(v: Vec<(String, String, String)>) -> Display {
+        Display {
+            contents: v.into_iter().map(|c| c.into()).collect(),
+        }
+    }
+}
+
+impl From<(String, String, String)> for Content {
+    fn from(c: (String, String, String)) -> Content {
+        Content {
+            name: c.0,
+            before: c.1,
+            after: c.2,
+        }
+    }
+}


### PR DESCRIPTION
Help
```bash
❯ cargo run -p fn -- setup --help
fn-setup
Setup configuration entry

USAGE:
    fn setup [OPTIONS]

OPTIONS:
    -h, --help                                               Print help information
    -s, --set-rpc-server-address <SET_RPC_SERVER_ADDRESS>    Set the address of Findora rpc server
```

Setup with nothing
```bash
❯ cargo run -p fn -- setup
💡 No changes made
```

Setup with something
```bash
❯ cargo run -p fn -- setup -s https://127.0.0.1:25576
📃 RPC Server Address
https://localhost:25576 ➤  https://127.0.0.1:25576
```
![image](https://user-images.githubusercontent.com/11532828/148191249-0eed1924-312f-4fa3-b1fa-4c67456de2a6.png)

Setup with the wrong format
```bash
❯ cargo run -p fn -- setup -s wrong-format
❌ Something Wrong...
🔥 address is not valid: wrong-format

❯ cargo run -p fn -- setup -s http:/something.wrong
❌ Something Wrong...
🔥 address is not valid: http:/something.wrong
```